### PR TITLE
Stability and Feature Rework

### DIFF
--- a/BeyondChaosUpdater/BeyondChaosUpdater.py
+++ b/BeyondChaosUpdater/BeyondChaosUpdater.py
@@ -1,3 +1,4 @@
+import configparser
 import platform
 from zipfile import ZipFile
 from configparser import ConfigParser
@@ -6,6 +7,8 @@ import os
 import time
 import sys
 import tempfile
+import remonstrate_utils
+import subprocess
 from pathlib import Path
 
 # This is not part of the stdlib
@@ -14,49 +17,98 @@ try:
 except ImportError:
     sys.exit("Please install the `requests` python package "
              "before running updater. Try `pip install requests`.")
-
-import remonstrate_utils
+import psutil
 
 __version__ = "2.0.0"
 
-DEFAULT_CONFIG = """
-[Version]
-Core=0.0.0
-Sprite=0.0.0
-Monster Sprite=0.0.0
-"""
+config = ConfigParser(strict=False)
+parent_process_id = [arg[len("-pid "):] for arg in sys.argv if arg.startswith("-pid ")] or None
 
-def write_default_config(fname="config.ini"):
-    with open(fname, "w") as fout:
-        print(DEFAULT_CONFIG, file=fout)
-
+BACKUP_NAME = backup_name = sys.argv[0] + ".old"
 _BASE_PROJ_URL = 'https://api.github.com/repos/FF6BeyondChaos/'
-_ASSET_URLS = {
-    "updater": os.path.join(_BASE_PROJ_URL, 'BeyondChaosUpdater/releases/latest'),
-    "core": os.path.join(_BASE_PROJ_URL, 'BeyondChaosRandomizer/releases/latest'),
-    "sprite": os.path.join(_BASE_PROJ_URL, 'BeyondChaosSprites/releases/latest'),
-    "monster_sprite": os.path.join(_BASE_PROJ_URL, 'BeyondChaosMonsterSprites/releases/latest')
+
+# Update: Does this asset require an update?
+# Prompt: What should be displayed to the user to confirm the update?
+# Location: Where should the asset be downloaded and extracted to?
+# URL: What web address is the asset located at?
+# Data: The data from the URL, so we don't need to hit the API multiple times.
+_ASSETS = {
+    "updater": {
+        "update": False,
+        "prompt": "There is an update available for this updater.\n"
+                  "Would you like to download the update from GitHub?\n",
+        "location": os.getcwd(),
+        "URL": os.path.join(_BASE_PROJ_URL, 'BeyondChaosUpdater/releases/latest'),
+        "data": {}
+    }
+    ,
+    "core": {
+        "update": False,
+        "prompt": "There is an update available for the Beyond Chaos core files.\n"
+                  "Would you like to download the update from GitHub?\n"
+                  "This will replace the version of Beyond Chaos you are currently running.\n",
+        "location": os.getcwd(),
+        "URL": os.path.join(_BASE_PROJ_URL, 'BeyondChaosRandomizer/releases/latest'),
+        "data": {}
+    }
+    ,
+    "character_sprites": {
+        "update": False,
+        "prompt": "There is an update available for Beyond Chaos' character sprites.\n"
+                  "Would you like to download the new sprites from GitHub?\n",
+        "location": os.path.join(os.getcwd(), "custom"),
+        "URL": os.path.join(_BASE_PROJ_URL, 'BeyondChaosSprites/releases/latest'),
+        "data": {}
+    }
+    ,
+    "monster_sprites": {
+        "update": False,
+        "prompt": "There is an update available for Beyond Chaos' monster sprites.\n"
+                  "Would you like to download the new sprites from GitHub?\n",
+        "location": os.path.join(os.getcwd(), "remonsterate"),
+        "URL": os.path.join(_BASE_PROJ_URL, 'BeyondChaosMonsterSprites/releases/latest'),
+        "data": {}
+    }
 }
+
+
 def get_version(asset):
-    resp = requests.get(_ASSET_URLS[asset])
+    resp = requests.get(_ASSETS[asset]["URL"])
     # check request result
     if not resp.ok:
-        sys.exit(f"GitHub returned a bad response. Details:\n{resp.reason}")
+        print(f"GitHub returned a bad response.\nDetails:{resp.reason}")
+        input("Press enter to exit...")
+        sys.exit()
     x = resp.json()
     return x['tag_name']
 
-def update_version(asset, dst=None):
-    x = requests.get(_ASSET_URLS[asset]).json()
+
+def update_asset_from_web(asset):
+    global config
+    global parent_process_id
+    if parent_process_id:
+        for proc in psutil.process_iter():
+            if proc.pid == int(parent_process_id[0]) and proc.name().startswith("BeyondChaos"):
+                print("Killing process.")
+                proc.kill()
+                time.sleep(3)
+        if psutil.pid_exists(int(parent_process_id[0])):
+            input("Failed to automatically stop BeyondChaos.exe. "
+                  "Please exit the program and then press any key. ")
+        else:
+            parent_process_id = None
+
+    data = _ASSETS[asset]["data"]
     # get the link to download the latest package
-    download_link = x['assets'][0]['browser_download_url']
+    download_link = data['assets'][0]['browser_download_url']
     # download the file and save it.
-    tmpdir = tempfile.mkdtemp()
-    local_filename = os.path.join(tmpdir, download_link.split('/')[-1])
+    temp_dir = tempfile.mkdtemp()
+    local_filename = os.path.join(temp_dir, download_link.split('/')[-1])
     with requests.get(download_link, stream=True) as r:
         with open(local_filename, 'wb') as f:
             shutil.copyfileobj(r.raw, f)
 
-    dst = dst or os.getcwd()
+    dst = _ASSETS[asset]["location"] or os.getcwd()
     with ZipFile(local_filename, 'r') as zip_obj:
         # Extract all the contents of zip file in different directory
         if not os.path.exists(dst):
@@ -65,120 +117,125 @@ def update_version(asset, dst=None):
         # wait 3 seconds
         time.sleep(3)
 
-    return local_filename, x['tag_name']
+    if asset == "monster_sprites":
+        update_remonsterate()
 
-def update_updater():
-    print("Updater is updating the randomizer updater")
-    update_version("updater", None)
-    print("Updater has downloaded the newest version of the updater as a .zip file. Please unzip and use this newest file. Quitting updater.")
-
-def update_monster_sprites(config):
-    print("Updater is updating the randomizer monster sprites")
-    _, tag = update_version("monster_sprite", "remonsterate")
-    config.set('Version', 'Monster Sprite', tag)
-    print("Updater has updated the randomizer monster sprites")
-
-def update_sprites(config):
-    print("Updater is updating the randomizer sprites")
-    _, tag = update_version("sprite", "custom")
-    config.set('Version', 'Sprite', tag)
-    print("Updater has updated the randomizer sprites")
-
-def update_beyond_chaos(config):
-    print("\n\nWould you like to update the Beyond Chaos core files? "
-          "This will download the latest stable release from "
-          "GitHub, replacing the version of Beyond Chaos you are currently running.")
-    choice = input("Y/N: ")
-    if choice.lower() == "y":
-        _, tag = update_version("core")
-        config.set('Version', 'Core', tag)
-        print("Updater has updated the randomizer core")
-    else:
-        print("Core update skipped.")
-
-def launch_beyond_chaos():
-    print("Launching Beyond Chaos")
-    os.startfile('BeyondChaos.exe')
-    # wait 3 seconds
-    time.sleep(3)
-
-def main(config_path=Path(os.path.join(os.getcwd(), "config.ini"))):
-    config = ConfigParser(strict=False)
-    running_os = platform.system()
-
-    print("Welcome to the updater, we are starting things up, "
-          "please do not close this window!")
-    # wait 5 seconds
-    print("Waiting 5 seconds for beyondchaos.exe to close")
-    time.sleep(5)
-    print("Checking to see if config file exists...")
-    if os.path.exists(config_path):
-        print("Config file was found, running updater.")
-        config.read(config_path)
-    else:
-        print("No config file found, running first setup please wait.")
-        write_default_config(config_path)
-        config.read(config_path)
-
-    print("Updater is checking for a new version of the randomizer updater")
-    if __version__ != get_version("updater"):
-        update_updater()
-        time.sleep(10)
+    if asset == "updater":
+        # The currently-running executable cannot be deleted, so we rename it instead
+        # Then, we download the latest version from GitHub
+        # Finally, we run the newly downloaded exe and exit this older version
+        if sys.argv[0].endswith("exe"):
+            os.rename(sys.argv[0], BACKUP_NAME)
+        print("The updater has been updated. Restarting...\n")
+        subprocess.Popen(args=[], executable=sys.argv[0])
         sys.exit()
     else:
-        print("No update required. You have the most current version!")
+        if config:
+            if not config.has_section("Version"):
+                config.add_section("Version")
+            config.set('Version', asset, data['tag_name'])
 
-    print("Updater is checking for a new version of the randomizer core")
-    if running_os != "Windows":
-        print("Cannot update randomizer executable for non-Windows OS.")
-    elif config.get('Version', 'Core') != get_version("core"):
-        update_beyond_chaos(config)
-    else:
-        print("No update required. You have the most current version!")
 
-    print("Updater is checking for a new version of the randomizer sprites")
-    if config.get('Version', 'Sprite') != get_version("sprite"):
-        update_sprites(config)
-    else:
-        print("No update required. You have the most current version!")
+def launch_beyond_chaos():
+    if os.path.isfile("BeyondChaos.exe"):
+        print("Launching Beyond Chaos")
+        subprocess.Popen(args=[], executable='BeyondChaos.exe')
+        # wait 3 seconds
+        time.sleep(3)
+        os.system('cls' if os.name == 'nt' else 'clear')
+        sys.exit()
 
-    print("Updater is checking for a new version of the randomizer monster sprites")
-    if config.get('Version', 'Monster Sprite') != get_version("monster_sprite"):
-        update_remonsterate(config)
-    else:
-        print("No update required. You have the most current version!")
+
+def main(config_path=Path(os.path.join(os.getcwd(), "config.ini"))):
+    # rates = requests.get("https://api.github.com/rate_limit").json()
+    # print(str(rates))
+    # return
+    global config
+    if os.path.exists(config_path):
+        config.read(config_path)
+
+    running_os = platform.system()
+
+    for asset in _ASSETS:
+        try:
+            if asset == "updater":
+                if __version__ != get_version(asset):
+                    _ASSETS["updater"]["update"] = True
+            else:
+                if asset == "core" and running_os != "Windows":
+                    print("Cannot update randomizer executable for non-Windows OS.")
+                    continue
+
+                if config.get('Version', asset) != get_version(asset):
+                    _ASSETS[asset]["update"] = True
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            _ASSETS[asset]["update"] = True
+
+        if _ASSETS[asset]["update"]:
+            _ASSETS[asset]["data"] = requests.get(_ASSETS[asset]["URL"]).json()
+            download_size = _ASSETS[asset]["data"]['assets'][0]['size']
+            if download_size < 1000:
+                size_suffix = "Bytes"
+            elif download_size < 1000000:
+                size_suffix = "KB"
+                download_size = round(download_size / 1000, 2)
+            elif download_size < 1000000000:
+                size_suffix = "MB"
+                download_size = round(download_size / 1000000, 2)
+            else:
+                size_suffix = "GB"
+                download_size = round(download_size / 1000000000, 2)
+            print(_ASSETS[asset]["prompt"] +
+                  "The download size is " + str(download_size) + " " + size_suffix + ".")
+            choice = input("Y/N: ")
+            if choice.lower() == "n":
+                _ASSETS[asset]["update"] = False
+                print(f"Skipping {asset.replace('_', ' ')} update.")
+
+            print("")
+
+    for asset in _ASSETS:
+        if _ASSETS[asset]["update"]:
+            print(f"Updating the Beyond Chaos {asset.replace('_', ' ')} files...")
+            update_asset_from_web(asset)
+            print(f"The Beyond Chaos {asset.replace('_', ' ')} have been updated.\n")
 
     print("Rewriting updated version information to configuration.")
     with open(config_path, 'w') as fout:
         config.write(fout)
 
-    print("Update completed all update tasks!")
+    print("Completed all update tasks!")
     if running_os == "Windows":
-        launch_beyond_chaos()
+        if not parent_process_id:
+            # If Beyond Chaos isn't already running, start it
+            launch_beyond_chaos()
+        else:
+            print("")
     else:
         print("Non-Windows OS detected, bypassing executable launch")
 
-def update_remonsterate(config):
+
+def update_remonsterate():
     # Create the remonsterate directory in the game directory
     base_directory = os.path.join(os.getcwd(), 'remonsterate')
     sprite_directory = os.path.join(base_directory, "sprites")
     image_file = os.path.join(base_directory, "images_and_tags.txt")
     monster_file = os.path.join(base_directory, "monsters_and_tags.txt")
 
-    os.makedirs(base_directory)
-    print("Remonsterate directory created.")
+    if not os.path.exists(base_directory):
+        os.makedirs(base_directory)
+        print("Remonsterate directory created.")
 
-    os.makedirs(sprite_directory)
-    print("Sprites directory created in remonsterate.")
-
-    update_monster_sprites(config)
+    if not os.path.exists(sprite_directory):
+        os.makedirs(sprite_directory)
+        print("Sprites directory created in remonsterate.")
 
     # Generate images_and_tags.txt file for remonsterate based on the sprites in the sprites folder
     tag_file = os.path.join(os.getcwd(), 'remonsterate\\images_and_tags.txt')
     try:
         remonstrate_utils.construct_tag_file_from_dirs(sprite_directory, tag_file)
         print("New images_and_tags file created in remonsterate.")
-    except IOError as e:
+    except IOError:
         remonstrate_utils.generate_tag_file(tag_file)
         if not os.path.isfile(image_file):
             print("Template images_and_tags file created in remonsterate.")
@@ -187,6 +244,7 @@ def update_remonsterate(config):
     if not os.path.isfile(monster_file):
         remonstrate_utils.generate_sample_monster_list(tag_file)
         print("Template monsters_and_tags file created in remonsterate.")
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- BeyondChaosUpdater can now update itself. It does so by renaming the currently running executable with .old, downloading the newest version to replace the file, and then running the new version.
- Created _ASSETS, which combines _ASSET_URLS and other asset information into a single object
- Changed update_version into update_asset_from_web. The function now uses parent_process_id supplied from BeyondChaos.exe to terminate BeyondChaos.exe when an update is applied, instead of BeyondChaos.exe always shutting itself down.
- Renamed the "sprite" asset to "character_sprites" for clarity
- When an update is detected, the program now prompts the user for each update. Included in the prompt is the download size for the update.
- BeyondChaos.exe is now launched using subprocess instead of os.startfile
- Collapsed the update_<asset> methods into update_asset_from_web, which also handles updating the config.
Update:
- Updated the internal updater version
- The updater now renames itself before trying to extract the new version and not after. Oops!
- Added comments
- The Updater now skips further questions if the updater itself would be updated. The updater has to restart anyway, and we don't want to ask the questions multiple times.