### PR TITLE
Added additional backup check

### DIFF
--- a/BeyondChaosUpdater/BeyondChaosUpdater.py
+++ b/BeyondChaosUpdater/BeyondChaosUpdater.py
@@ -22,7 +22,7 @@ except ImportError:
     sys.exit("Please install the `psutil` python package "
              "before running updater. Try `pip install psutil`.")
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 config = ConfigParser(strict=False)
 parent_process_id = [arg[len("-pid "):] for arg in sys.argv if arg.startswith("-pid ")] or None
@@ -178,6 +178,9 @@ def update_asset_from_web(asset):
                             else:
                                 prompting = True
                                 print("Please answer Y for yes or N for no.")
+                    else:
+                        # If the hash for the asset does not exist, we can just back up the files to be safe
+                        back_up_sprites = True
                 else:
                     # If the hash for the asset does not exist, we can just back up the files to be safe
                     back_up_sprites = True


### PR DESCRIPTION
BeyondChaosUpdater.py:
- A backup will now be created of character sprites or monster sprites if a value does not exist for the asset under the hashes section of config.ini. Previously it would only create a backup if the entire hashes section was missing.